### PR TITLE
specify width and height for image picker options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spatialconnect-form-schema",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "",
   "main": "web/index.js",
   "scripts": {

--- a/src/formtemplates/photo.native.js
+++ b/src/formtemplates/photo.native.js
@@ -24,6 +24,8 @@ class SCFormPhoto extends Component {
     var options = {
       title: this.props.title,
       quality: 0.1,
+      maxWidth: 1920,
+      maxHeight: 1080,
       storageOptions: {
         skipBackup: true,
         path: 'images'


### PR DESCRIPTION
@frankrowe 

This is to prevent android from crashing when trying to resize very large high res photos.
