### PR TITLE
check and display form validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-register": "^6.8.0",
     "classnames": "2.2.5",
     "expect": "^1.20.1",
+    "immutability-helper": "^2.2.3",
     "jsonschema": "^1.1.0",
     "lodash": "^4.12.0",
     "mocha": "^2.5.1",

--- a/src/SCForm.native.js
+++ b/src/SCForm.native.js
@@ -14,6 +14,7 @@ import {
   View,
 } from 'react-native';
 import translate from './translate';
+import validateFields from './validateFields';
 import transform from 'tcomb-json-schema';
 import tcomb from 'tcomb-form-native';
 import scstyles from './scstyles';
@@ -79,14 +80,15 @@ class SCForm extends Component {
   }
 
   onSubmit() {
-    const formData = this.form.getValue();
-    if (formData) {
-      Alert.alert('Submit Form', 'Would you like to submit this form?', [
-        { text: 'Cancel' },
-        { text: 'Submit', onPress: () => this.props.saveForm(formData) },
-      ]);
+    if (validateFields(this.form)) {
+      const formData = this.form.getValue();
+      if (formData) {
+        Alert.alert('Submit Form', 'Would you like to submit this form?', [
+          { text: 'Cancel' },
+          { text: 'Submit', onPress: () => this.props.saveForm(formData) },
+        ]);
+      }
     }
-    // validation here?
   }
   formSubmitted() {
     // https://github.com/facebook/react-native/issues/10471

--- a/src/SCForm.native.js
+++ b/src/SCForm.native.js
@@ -75,19 +75,34 @@ class SCForm extends Component {
     }).start();
   }
 
+  getValue() {
+    let values = {};
+    let fields = this.form.refs.input.refs;
+
+    for (let ref in fields) {
+      if (fields.hasOwnProperty(ref)) {
+        values[ref] = fields[ref].getValue();
+      }
+    }
+
+    return values;
+  }
+
   onChange(value) {
     this.setState({ value });
   }
 
   onSubmit() {
-    if (validateFields(this.form)) {
-      const formData = this.form.getValue();
-      if (formData) {
-        Alert.alert('Submit Form', 'Would you like to submit this form?', [
-          { text: 'Cancel' },
-          { text: 'Submit', onPress: () => this.props.saveForm(formData) },
-        ]);
-      }
+    const formData = this.getValue();
+
+    let result = validateFields(formData, this.state.schema, this.state.options);
+    this.setState({ options: result.options });
+
+    if (!result.hasError) {
+      Alert.alert('Submit Form', 'Would you like to submit this form?', [
+        { text: 'Cancel' },
+        { text: 'Submit', onPress: () => this.props.saveForm(formData) },
+      ]);
     }
   }
   formSubmitted() {
@@ -125,7 +140,7 @@ class SCForm extends Component {
               }}
               value={this.state.value}
               type={this.TcombType}
-              options={this.options}
+              options={this.state.options}
               onChange={this.onChange}
             />
           </View>

--- a/src/translate.js
+++ b/src/translate.js
@@ -38,26 +38,24 @@ function translate({ scSchema, onFocus }) {
       underlineColorAndroid: 'transparent',
       onFocus: onFocus ? onFocus : () => {},
     };
+
+    fieldOptions.config = field;
+
     if (field.type == 'string' || field.type == 'number') {
-      fieldOptions.template = formtemplates.text;
-      fieldOptions.config = field;
       fieldOptions.config.fieldType = field.type;
+      fieldOptions.template = formtemplates.text;
     }
     if (field.type == 'photo') {
       field.type = 'string';
       fieldOptions.template = formtemplates.photo;
-      fieldOptions.config = field;
-      fieldOptions.error = 'Photo is Required';
     }
     if (field.type == 'counter') {
       field.type = 'number';
       fieldOptions.template = formtemplates.counter;
-      fieldOptions.config = field;
     }
     if (field.type == 'slider') {
       field.type = 'number';
       fieldOptions.template = formtemplates.slider;
-      fieldOptions.config = field;
     }
     if (field.type == 'select') {
       field.type = 'string';
@@ -71,6 +69,7 @@ function translate({ scSchema, onFocus }) {
     if (field.type == 'boolean') {
       fieldOptions.template = formtemplates.checkbox;
     }
+
     for (let key in fieldMap) {
       if (field.hasOwnProperty(key)) {
         field[fieldMap[key]] = field[key];

--- a/src/translate.js
+++ b/src/translate.js
@@ -40,7 +40,8 @@ function translate({ scSchema, onFocus }) {
     };
     if (field.type == 'string' || field.type == 'number') {
       fieldOptions.template = formtemplates.text;
-      fieldOptions.config = { fieldType: field.type };
+      fieldOptions.config = field;
+      fieldOptions.config.fieldType = field.type;
     }
     if (field.type == 'photo') {
       field.type = 'string';

--- a/src/validateFields.js
+++ b/src/validateFields.js
@@ -1,0 +1,65 @@
+function validateFields(form) {
+  let valid = true;
+
+  let refs = form.refs.input.refs;
+  for (let ref in refs) {
+    if (refs.hasOwnProperty(ref)) {
+      if (validateFormField(refs[ref])) {
+        valid = false;
+      }
+    }
+  }
+
+  return valid;
+}
+
+function validateFormField(field) {
+  let options = {};
+  if (field.props && field.props.hasOwnProperty('options')) {
+    options = field.props.options;
+  } else {
+    return true;
+  }
+
+  let value = field.props.value;
+  let config = options.hasOwnProperty('config') ? options.config : {};
+  let errorMsgs = [];
+
+  if (config.hasOwnProperty('required')) {
+    let required = config.required;
+    if (required && !value) {
+      errorMsgs.push('value is required');
+    }
+  }
+
+  if (config.hasOwnProperty('minimum')) {
+    let minimum = Number(config.minimum);
+    if (value < minimum) {
+      errorMsgs.push('value must be >= ' + minimum);
+    }
+  }
+
+  if (config.hasOwnProperty('maximum')) {
+    let maximum = Number(config.maximum);
+    if (value > maximum) {
+      errorMsgs.push('value must be <= ' + maximum);
+    }
+  }
+
+  let errors = errorMsgs.join('\n');
+  // if we have error messages, and it's different than what's already there
+  if (errors !== options.error) {
+    options.error = errors;
+    // then we must force an update if options.hasError is already true
+    if (field.hasError()) {
+      field.forceUpdate();
+    }
+  }
+  let hasErrors = errors.length > 0;
+  // otherwise the field will be updated normally
+  field.setState({ hasError: hasErrors });
+
+  return hasErrors;
+}
+
+export default validateFields;

--- a/src/validateFields.js
+++ b/src/validateFields.js
@@ -21,17 +21,20 @@ function validateFormField(field) {
     return true;
   }
 
-  let value = field.props.value;
+  let value = field.getValue();
   let config = options.hasOwnProperty('config') ? options.config : {};
   let errorMsgs = [];
 
-  if (config.hasOwnProperty('required')) {
-    let required = config.required;
-    if (required && !value) {
+  // required - value must be provided
+  if (config.hasOwnProperty('required') && config.required && !value) {
+    // allow booleans to be false (yes/no fields)
+    // allow number fields (esp. sliders) to be 0
+    if ((config.type == 'number' && value != 0) || config.type != 'boolean') {
       errorMsgs.push('value is required');
     }
   }
 
+  // minimum - value must be numerically >= to minimum
   if (config.hasOwnProperty('minimum')) {
     let minimum = Number(config.minimum);
     if (value < minimum) {
@@ -39,10 +42,35 @@ function validateFormField(field) {
     }
   }
 
+  // maximum - value must be numerically <= to maximum
   if (config.hasOwnProperty('maximum')) {
     let maximum = Number(config.maximum);
     if (value > maximum) {
       errorMsgs.push('value must be <= ' + maximum);
+    }
+  }
+
+  // minLength - value must have at least minLength characters
+  if (config.hasOwnProperty('minLength')) {
+    let minLength = config.minLength;
+    if (String(value).length < minLength) {
+      errorMsgs.push('value must have ' + minLength + ' characters');
+    }
+  }
+
+  // maxLength - value must have less than maxLength characters
+  if (config.hasOwnProperty('maxLength')) {
+    let maxLength = config.maxLength;
+    if (String(value).length > maxLength) {
+      errorMsgs.push('value must have less than ' + maxLength + ' characters');
+    }
+  }
+
+  // pattern - value must match specified regular expression
+  if (config.hasOwnProperty('pattern')) {
+    let pattern = RegExp(config.pattern);
+    if (!pattern.test(value)) {
+      errorMsgs.push('value does not match pattern: ' + pattern);
     }
   }
 


### PR DESCRIPTION
This adds running the validations before form submission, and should appropriately show error messages below fields. This probably completes [UMC-41](https://issues.boundlessgeo.com:8443/browse/UMC-41).

`required`, numeric `minimum` and `maximum` seem to be working correctly. All other value constraints need to be added for [UMC-42](https://issues.boundlessgeo.com:8443/browse/UMC-42).