### PR TITLE
Fix unnecessary scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spatialconnect-form-schema",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "web/index.js",
   "scripts": {


### PR DESCRIPTION
Changes auto scrolling behavior to only scroll to the focused input when the field is hidden behind the keyboard.

Tested on iOS + Android.