### PR TITLE
fixing multiline text input for react-native 0.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spatialconnect-form-schema",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "web/index.js",
   "scripts": {

--- a/src/formtemplates/text.native.js
+++ b/src/formtemplates/text.native.js
@@ -15,12 +15,15 @@ class SCTextInput extends Component {
       <TextInput
         {...this.props}
         ref={view => (this.textInput = view)}
-        onChange={event => {
-          this.setState({
-            height: event.nativeEvent.contentSize.height,
-          });
+        onContentSizeChange={event => {
+          if (event && event.nativeEvent && event.nativeEvent.contentSize) {
+            this.setState({
+              height: event.nativeEvent.contentSize.height + 10,
+            });
+          }
+          this.props.onContentSizeChange && this.props.onContentSizeChange(event);
         }}
-        style={[this.props.style, { height: Math.max(44, this.state.height) }]}
+        style={[this.props.style, { height: Math.max(35, this.state.height) }]}
       />
     );
   }


### PR DESCRIPTION
the original code caused a crash, i believe because something was changed in react-native between 0.44.x and 0.47.2 where contentSize or nativeEvent weren't available anymore. However, just adding a `if !null` checks still didn't actually make the multiline text inputs automatically grow again. Seems to be working again on both platforms.

we should also probably publish this again?