### PR TITLE
update prop-types for newer react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spatialconnect-form-schema",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "",
   "main": "web/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/boundlessgeo/spatialconnect-form-schema"
   },
-  "author": "Frank Rowe <frowe@boundlessgeo.com> (http://boundlessgeo.com)",
+  "author": "Boundless Spatial, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
     "babel": "^6.5.2",
@@ -31,8 +31,12 @@
     "jsonschema": "^1.1.0",
     "lodash": "^4.12.0",
     "mocha": "^2.5.1",
+    "prop-types": "^15.5.7",
     "proxyquire": "^1.7.9",
     "tcomb-form": "^0.9.5",
     "webpack": "^1.13.0"
+  },
+  "peerDependencies": {
+    "react": "^15.5.0"
   }
 }

--- a/src/SCForm.native.js
+++ b/src/SCForm.native.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -15,6 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import translate from './translate';
 import validateFields from './validateFields';
 import transform from 'tcomb-json-schema';


### PR DESCRIPTION
For apps that require a version of React > v15.5.0, we'll need to migrate away from using `React.PropTypes`.  This PR updates the lib to use the `prop-types` package instead of `React.PropTypes`.

For more info, see [this](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) 